### PR TITLE
Check GOOGLE_PROTOBUF_VERSION for using ByteSizeLong

### DIFF
--- a/src/sync/chrono-sync2013.cpp
+++ b/src/sync/chrono-sync2013.cpp
@@ -314,7 +314,13 @@ ChronoSync2013::Impl::processRecoveryInterest
     }
 
     if (tempContent.ss_size() != 0) {
-      ptr_lib::shared_ptr<vector<uint8_t> > array(new vector<uint8_t>(tempContent.ByteSizeLong()));
+      ptr_lib::shared_ptr<vector<uint8_t> > array(new vector<uint8_t>(
+#if GOOGLE_PROTOBUF_VERSION < 3004000
+        tempContent.ByteSize()
+#else
+        tempContent.ByteSizeLong()
+#endif
+        ));
       tempContent.SerializeToArray(&array->front(), array->size());
       Data data(interest.getName());
       data.setContent(Blob(array, false));
@@ -383,7 +389,13 @@ ChronoSync2013::Impl::processSyncInterest
   if (tempContent.ss_size() != 0) {
     Name name(applicationBroadcastPrefix_);
     name.append(syncDigest);
-    ptr_lib::shared_ptr<vector<uint8_t> > array(new vector<uint8_t>(tempContent.ByteSizeLong()));
+    ptr_lib::shared_ptr<vector<uint8_t> > array(new vector<uint8_t>(
+#if GOOGLE_PROTOBUF_VERSION < 3004000
+      tempContent.ByteSize()
+#else
+      tempContent.ByteSizeLong()
+#endif
+      ));
     tempContent.SerializeToArray(&array->front(), array->size());
     Data data(name);
     data.setContent(Blob(array, false));
@@ -576,7 +588,13 @@ void
 ChronoSync2013::Impl::broadcastSyncState
   (const string& digest, const Sync::SyncStateMsg& syncMessage)
 {
-  ptr_lib::shared_ptr<vector<uint8_t> > array(new vector<uint8_t>(syncMessage.ByteSizeLong()));
+  ptr_lib::shared_ptr<vector<uint8_t> > array(new vector<uint8_t>(
+#if GOOGLE_PROTOBUF_VERSION < 3004000
+    syncMessage.ByteSize()
+#else
+    syncMessage.ByteSizeLong()
+#endif
+    ));
   syncMessage.SerializeToArray(&array->front(), array->size());
   Data data(applicationBroadcastPrefix_);
   data.getName().append(digest);


### PR DESCRIPTION
Since Protobuf version 3.4, ByteSize has been deprecated in favor of ByteSizeLong. Some compilers like VisualStudio treat the deprecation as an error, so we need to use ByteSizeLong. But other platforms still have older Protobuf packages such as version 3.0 on Ubunuto 18.04. This pull request updates `ChronoSync2013` to check the Protobuf version and to use ByteSize if older than 3.4 .