### PR TITLE
TpmPrivateKey: Support AES-256-CBC and HMAC-WITH-SHA256.

### DIFF
--- a/include/ndn-ind/lite/util/crypto-lite.hpp
+++ b/include/ndn-ind/lite/util/crypto-lite.hpp
@@ -216,6 +216,43 @@ public:
   }
 
   /**
+   * Compute the PBKDF2 with HMAC SHA256 of the password.
+   * @param password The input password, which should have characters in the range
+   * of 1 to 127.
+   * @param passwordLength The length of password.
+   * @param salt The 8-byte salt.
+   * @param saltLength The length of salt, which should be 8.
+   * @param nIterations  The number of iterations of the hashing algorithm.
+   * @param resultLength The number of bytes of the result array.
+   * @param result A pointer to a buffer of size resultLength to receive the
+   * result.
+   */
+  static void
+  computePbkdf2WithHmacSha256
+    (const uint8_t* password, size_t passwordLength, const uint8_t* salt,
+     size_t saltLength, int nIterations, size_t resultLength, uint8_t* result);
+
+  /**
+   * Compute the PBKDF2 with HMAC SHA256 of the password.
+   * @param password The input password, which should have characters in the range
+   * of 1 to 127.
+   * @param salt The 8-byte salt.
+   * @param nIterations  The number of iterations of the hashing algorithm.
+   * @param resultLength The number of bytes of the result array.
+   * @param result A pointer to a buffer of size resultLength to receive the
+   * result.
+   */
+  static void
+  computePbkdf2WithHmacSha256
+    (const BlobLite& password, const BlobLite& salt, int nIterations,
+     size_t resultLength, uint8_t *result)
+  {
+    computePbkdf2WithHmacSha256
+      (password.buf(), password.size(), salt.buf(), salt.size(), nIterations,
+       resultLength, result);
+  }
+
+  /**
    * Compute the MurmurHash3 of the data.
    * @param nHashSeed The hash seed.
    * @param dataToHash A pointer to the input byte array to hash.

--- a/src/c/util/crypto.c
+++ b/src/c/util/crypto.c
@@ -111,6 +111,16 @@ ndn_computePbkdf2WithHmacSha1
      saltLength, nIterations, resultLength, (unsigned char *)result);
 }
 
+void
+ndn_computePbkdf2WithHmacSha256
+  (const uint8_t *password, size_t passwordLength, const uint8_t *salt,
+   size_t saltLength, int nIterations, size_t resultLength, uint8_t *result)
+{
+  PKCS5_PBKDF2_HMAC
+    ((const char *)password, passwordLength, (const unsigned char *)salt,
+     saltLength, nIterations, EVP_sha256(), resultLength, (unsigned char *)result);
+}
+
 size_t
 ndn_getEcKeyInfoCount() { return sizeof(EC_KEY_INFO) / sizeof(EC_KEY_INFO[0]); }
 

--- a/src/c/util/crypto.h
+++ b/src/c/util/crypto.h
@@ -133,6 +133,23 @@ ndn_computePbkdf2WithHmacSha1
    size_t saltLength, int nIterations, size_t resultLength, uint8_t *result);
 
 /**
+ * Compute the PBKDF2 with HMAC SHA256 of the password.
+ * @param password The input password, which should have characters in the range
+ * of 1 to 127.
+ * @param passwordLength The length of password.
+ * @param salt The 8-byte salt.
+ * @param saltLength The length of salt, which should be 8.
+ * @param nIterations  The number of iterations of the hashing algorithm.
+ * @param resultLength The number of bytes of the result array.
+ * @param result A pointer to a buffer of size resultLength to receive the
+ * result.
+ */
+void
+ndn_computePbkdf2WithHmacSha256
+  (const uint8_t *password, size_t passwordLength, const uint8_t *salt,
+   size_t saltLength, int nIterations, size_t resultLength, uint8_t *result);
+
+/**
  * Get the number of ndn_EcKeyInfo struct entries in the array.
  * @return The number of entries.
  */

--- a/src/lite/util/crypto-lite.cpp
+++ b/src/lite/util/crypto-lite.cpp
@@ -90,6 +90,16 @@ CryptoLite::computePbkdf2WithHmacSha1
      result);
 }
 
+void
+CryptoLite::computePbkdf2WithHmacSha256
+  (const uint8_t* password, size_t passwordLength, const uint8_t* salt,
+   size_t saltLength, int nIterations, size_t resultLength, uint8_t* result)
+{
+  ndn_computePbkdf2WithHmacSha256
+    (password, passwordLength, salt, saltLength, nIterations, resultLength,
+     result);
+}
+
 #endif
 
 bool


### PR DESCRIPTION
Background: The method `TpmPrivateKey::loadEncryptedPkcs8` decodes a password-protected PKCS 8 private key. Inside the encoding the are algorithms identifiers to identify the encryption scheme. This is used when the `KeyChain` is importing a safe bag. The latest version of `ndnsec` uses newer algorithms not yet supported.

This pull request has two commits. The first commit adds support for the algorithm Pbkdf2WithHmacSha256 which is used in deriving the decryption key from the password.

The second pull request updates `loadEncryptedPkcs8` to support Pbkdf2WithHmacSha256 and also AES-256-CBC. Now the library can be used to import a safe bag from the latest ndnsec.