### PR TITLE
In loadCertificate, log the certificate names that are loaded

### DIFF
--- a/src/security/v2/trust-anchor-group.cpp
+++ b/src/security/v2/trust-anchor-group.cpp
@@ -219,6 +219,8 @@ DynamicTrustAnchorGroup::loadCertificate
 {
   ptr_lib::shared_ptr<CertificateV2> certificate = readCertificate(file);
   if (certificate) {
+    _LOG_TRACE("Loaded trust anchor certificate " << certificate->getName().toUri() <<
+      " from file: " << file);
     if (!certificate->isValid()) {
       _LOG_INFO("Dynamic trust anchor is out of validity. Not loaded. " << certificate->getName().toUri());
       return;
@@ -231,6 +233,8 @@ DynamicTrustAnchorGroup::loadCertificate
     else
       oldAnchorNames.erase(certificate->getName());
   }
+  else
+    _LOG_TRACE("Could not read certificate from file: " << file);
 }
 
 }


### PR DESCRIPTION
The certificate Validator loads certificates from the trust anchors directory. For TRACE debugging, it would be useful to see the file and certificate names. This pull request updates the `loadCertificate` method to log the filename and certificate name of the loaded certificate (or a message if cannot parse the file).