### PR TITLE
In file-based Pib and Tpm, update directory support for Windows

### DIFF
--- a/src/security/tpm/tpm-back-end-file.cpp
+++ b/src/security/tpm/tpm-back-end-file.cpp
@@ -66,12 +66,18 @@ TpmBackEndFile::TpmBackEndFile(const string& locationPath)
       keyStorePath_.erase(keyStorePath_.size() - 1);
   }
   else {
+#if defined(_WIN32)
+    const char* homeDrive = getenv("HOMEDRIVE");
+    const char* homePath = getenv("HOMEPATH");
+    string home = (!homeDrive || !homePath ? "." : string(homeDrive) + string(homePath));
+#else
     // Note: We don't use <filesystem> support because it is not "header-only"
     // and requires linking to libraries.
     const char* home = getenv("HOME");
     if (!home || *home == '\0')
       // Don't expect this to happen;
       home = ".";
+#endif
     string homeDir(home);
     if (homeDir[homeDir.size() - 1] == '/' || homeDir[homeDir.size() - 1] == '\\')
       // Strip the ending path separator.
@@ -83,7 +89,7 @@ TpmBackEndFile::TpmBackEndFile(const string& locationPath)
 
   // ::mkdir will work if the parent directory already exists, which is most cases.
 #if defined(_WIN32)
-  int status = ::_mkdir(keyStorePath_.c_str());
+  int status = -1;
 #else
   int status = ::mkdir(keyStorePath_.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
 #endif


### PR DESCRIPTION
The security classes `PibSqlite3` and `TpmBackEndFile` create directories to store files, where the default directory is .ndn in the user's home directory. We need to support this on Windows.

This pull request has two commits. The first commit updates `PibSqlite3` as follows. On Unix, the constructor first tries to use `mkdir` to create the directory. We want to skip this on Windows, so we set the following status code which means `mkdir` didn't succeed.

    int status = -1;

To create the directory, we need to call `create_directories` defined either by Boost or the C++17 standard library. Therefore, we need to check for NDN_IND_HAVE_BOOST_FILESYSTEM or NDN_IND_HAVE_CXX17 the same way as the #include directive which is [already defined](https://github.com/remap/ndn-ind/blob/app-forwarder/src/security/pib/pib-sqlite3.cpp#L44-L50) as follows:

    #ifdef NDN_IND_HAVE_BOOST_FILESYSTEM
    #include <boost/filesystem.hpp>
    #else
    #ifdef NDN_IND_HAVE_CXX17
    #include <filesystem>
    #endif
    #endif

Also, the method `getDefaultDatabaseDirectoryPath` finds the user's home directory and returns the path of the .ndn subdirectory, but it doesn't need to create the directory. (This is done by the constructor as described above.) So, this removes the code to create a directory from `getDefaultDatabaseDirectoryPath` and updates to use HOMEDRIVE and HOMEPATH for Windows (instead of HOME for Unix).

The second commit updates `TpmBackEndFile` in a similar way. In the constructor we update to use HOMEDRIVE and HOMEPATH for Windows. And for Windows we set the status code to -1 so that we don't call `mkdir`.

With these changes, as expected, the default `KeyChain` constructor uses the user's home directory to create the Pib sqlite files and the directory for file-based private keys.